### PR TITLE
feat: add support for initialStepIndex (#26)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -31,6 +31,15 @@
       "contributions": [
         "ideas"
       ]
+    },
+    {
+      "login": "kaYcee",
+      "name": "kaYcee",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/1464822?v=4",
+      "profile": "https://github.com/kaYcee",
+      "contributions": [
+        "ideas"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Take a look at those examples to get an idea of what's possible.
   <tr>
     <td align="center"><a href="https://turnpro.in"><img src="https://avatars3.githubusercontent.com/u/19505532?v=4" width="100px;" alt="Johannes Kling"/><br /><sub><b>Johannes Kling</b></sub></a><br /><a href="https://github.com/Jibbedi/react-wizard-primitive/commits?author=Jibbedi" title="Code">💻</a> <a href="https://github.com/Jibbedi/react-wizard-primitive/commits?author=Jibbedi" title="Documentation">📖</a> <a href="#ideas-Jibbedi" title="Ideas, Planning, & Feedback">🤔</a> <a href="#example-Jibbedi" title="Examples">💡</a> <a href="https://github.com/Jibbedi/react-wizard-primitive/commits?author=Jibbedi" title="Tests">⚠️</a></td>
     <td align="center"><a href="http://www.josemiguel.org"><img src="https://avatars0.githubusercontent.com/u/6037190?v=4" width="100px;" alt="Jose Miguel Bejarano"/><br /><sub><b>Jose Miguel Bejarano</b></sub></a><br /><a href="#ideas-xDae" title="Ideas, Planning, & Feedback">🤔</a></td>
+    <td align="center"><a href="https://github.com/kaYcee"><img src="https://avatars1.githubusercontent.com/u/1464822?v=4" width="100px;" alt="kaYcee"/><br /><sub><b>kaYcee</b></sub></a><br /><a href="#ideas-kaYcee" title="Ideas, Planning, & Feedback">🤔</a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -75,45 +75,57 @@ import { Wizard, WizardStep } from "react-wizard-primitive";
 
 ## Hooks API
 
+### Props
+
+You can optionally pass an `UseWizardProps` into the hooks.
+
+#### initialStepIndex
+
+> number
+
+Sets the `activeStepIndex` to the given index. All previous steps will be treated as if they've been already activated.
+
+### Return Values
+
 The useWizard API returns the state and a set of helper functions.
 
-### activeStepIndex
+#### activeStepIndex
 
 > number
 
 Currently active step
 
-### maxActivatedStepIndex
+#### maxActivatedStepIndex
 
 > number
 
 Index of the furthest step, that has been activated
 
-### nextStep
+#### nextStep
 
 > function
 
 Call this to proceed to the next step
 
-### previousStep
+#### previousStep
 
 > function
 
 Call this to proceed to the previous step
 
-### moveToStep
+#### moveToStep
 
 > function(stepIndex : number)
 
 Move to step with index _stepIndex_
 
-### resetToStep
+#### resetToStep
 
 > function(stepIndex : number)
 
 Move to step with index _stepIndex_. Set _hasBeenActive_ for all following steps as well as the new step to false.
 
-### getStep
+#### getStep
 
 > function(options?) : Step
 
@@ -150,6 +162,14 @@ The Wizard component uses **useWizard** internally and exposes a compound compon
 Use this as a top level component for the wizard and put any number of _WizardSteps_ in it.
 
 You can _optionally_ provide a render prop, which gets passed the same values that _useWizard_ returns.
+
+#### Props
+
+#### initialStepIndex
+
+> number
+
+Sets the `activeStepIndex` to the given index. All previous steps will be treated as if they've been already activated.
 
 ### WizardStep
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,11 +32,17 @@ export interface Step {
   moveToStep: () => void;
 }
 
+export interface UseWizardProps {
+  initialStepIndex?: number;
+}
+
 const WizardContext = React.createContext<UseWizard | null>(null);
 
-export const useWizard = () => {
-  const [activeStepIndex, setActiveStepIndex] = useState(0);
-  const [maxActivatedStepIndex, setMaxActivatedStepIndex] = useState(-1);
+export const useWizard = ({ initialStepIndex = 0 }: UseWizardProps = {}) => {
+  const [activeStepIndex, setActiveStepIndex] = useState(initialStepIndex);
+  const [maxActivatedStepIndex, setMaxActivatedStepIndex] = useState(
+    initialStepIndex - 1
+  );
 
   // each getStep call with add the corresponding step title or undefined if none is provided
   const stepTitles: (string | undefined)[] = [];
@@ -140,10 +146,11 @@ export const useWizard = () => {
 
 export interface WizardProps {
   children: ((useWizard: UseWizard) => React.ReactNode) | React.ReactNode;
+  initialStepIndex?: number;
 }
 
 export const Wizard: FunctionComponent<WizardProps> = (props: WizardProps) => {
-  const internalState = useWizard();
+  const internalState = useWizard({ initialStepIndex: props.initialStepIndex });
   return (
     <WizardContext.Provider value={{ ...internalState }}>
       {typeof props.children === "function"

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -26,9 +26,9 @@ const HooksComponent = () => {
   );
 };
 
-const TestComponent = () => {
+const TestComponent = ({ initialStepIndex = 0 }) => {
   return (
-    <Wizard>
+    <Wizard initialStepIndex={initialStepIndex}>
       {({
         activeStepIndex,
         maxActivatedStepIndex,
@@ -316,4 +316,11 @@ test("it should throw an exception if WizardStep is used standalone", () => {
   expect(() => {
     render(<WizardStep>{() => null}</WizardStep>);
   }).toThrow();
+});
+
+test("it should respect initial step index", () => {
+  const container = render(<TestComponent initialStepIndex={1} />);
+
+  verifyOnlySecondStepIsVisible(container);
+  expect(container.queryByTestId("maxIndex")!.textContent).toBe("0");
 });


### PR DESCRIPTION
You can now pass in an `initialStepIndex` to the `useWizard` hook or the `Wizard` component. The wizard will start at the given step. All previous steps will be marked as `active === true`.

closes #26 