### PR TITLE
feat: Add `onChange` handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ You can optionally pass an `UseWizardProps` into the hooks.
 
 Sets the `activeStepIndex` to the given index. All previous steps will be treated as if they've been already activated.
 
+#### onChange
+
+> function({newStepIndex : number, previousStepIndex: number, maxActivatedStepIndex : number})
+
+Is called every time the wizard step changes.
+
 ### Return Values
 
 The useWizard API returns the state and a set of helper functions.
@@ -170,6 +176,12 @@ You can _optionally_ provide a render prop, which gets passed the same values th
 > number
 
 Sets the `activeStepIndex` to the given index. All previous steps will be treated as if they've been already activated.
+
+#### onChange
+
+> function({newStepIndex : number, previousStepIndex: number, maxActivatedStepIndex : number})
+
+Is called every time the wizard step changes.
 
 ### WizardStep
 

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -3,6 +3,7 @@ import { useWizard, Wizard, WizardStep } from "../src";
 import { cleanup, fireEvent, render } from "react-testing-library";
 
 afterEach(cleanup);
+afterEach(jest.clearAllMocks);
 
 const HooksComponent = () => {
   const wizard = useWizard();
@@ -26,9 +27,9 @@ const HooksComponent = () => {
   );
 };
 
-const TestComponent = ({ initialStepIndex = 0 }) => {
+const TestComponent = ({ initialStepIndex = 0, onChange = null }: any) => {
   return (
-    <Wizard initialStepIndex={initialStepIndex}>
+    <Wizard initialStepIndex={initialStepIndex} onChange={onChange}>
       {({
         activeStepIndex,
         maxActivatedStepIndex,
@@ -323,4 +324,25 @@ test("it should respect initial step index", () => {
 
   verifyOnlySecondStepIsVisible(container);
   expect(container.queryByTestId("maxIndex")!.textContent).toBe("0");
+});
+
+test("it should call onChange handler", () => {
+  const handler = jest.fn();
+
+  const container = render(<TestComponent onChange={handler} />);
+  expect(handler).not.toHaveBeenCalled();
+
+  fireEvent.click(container.queryByTestId("next-button")!);
+  expect(handler).toHaveBeenCalledWith({
+    previousStepIndex: 0,
+    newStepIndex: 1,
+    maxActivatedStepIndex: 0
+  });
+
+  fireEvent.click(container.queryByTestId("prev-button")!);
+  expect(handler).toHaveBeenCalledWith({
+    previousStepIndex: 1,
+    newStepIndex: 0,
+    maxActivatedStepIndex: 1
+  });
 });


### PR DESCRIPTION
The onChange handler is called for every step change. It is provided with the previous, next and
maxActivated step indices.

closes #30