### PR TITLE
fix(routing): prevent route hash to be #undefined

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import React, {
   useContext,
   useEffect,
   useRef,
-  useState
+  useState,
 } from "react";
 import { getRoutingHash, setRoutingHash } from "./routing";
 
@@ -61,7 +61,7 @@ const WizardContext = React.createContext<UseWizard | null>(null);
 
 export const useWizard = ({
   initialStepIndex = 0,
-  onChange
+  onChange,
 }: UseWizardProps = {}) => {
   const [activeStepIndex, setActiveStepIndex] = useState(initialStepIndex);
   const [maxActivatedStepIndex, setMaxActivatedStepIndex] = useState(
@@ -84,7 +84,14 @@ export const useWizard = ({
 
   // update location hash
   useEffect(() => {
-    const stepsWithTitle = stepTitles.filter(title => !!title);
+    /*
+      return early if no step has been created
+    */
+    if (stepCheckIndex === 0) {
+      return;
+    }
+
+    const stepsWithTitle = stepTitles.filter((title) => !!title);
     const allStepTitlesAvailable = stepsWithTitle.length === stepCheckIndex;
     const allStepTitlesMissing = stepsWithTitle.length === 0;
 
@@ -97,7 +104,7 @@ export const useWizard = ({
     if (!allStepTitlesMissing) {
       const indicesOfMissingTitles = stepTitles
         .map((title, index) => (!title ? index : null))
-        .filter(title => title !== null);
+        .filter((title) => title !== null);
 
       console.warn(
         `You have not specified a title for the steps with the indices: ${indicesOfMissingTitles.join(
@@ -110,7 +117,7 @@ export const useWizard = ({
   }, [activeStepIndex]);
 
   const getStep: (options?: GetStepOptions) => Step = ({
-    routeTitle
+    routeTitle,
   }: GetStepOptions = {}) => {
     const stepIndex = stepCheckIndex;
 
@@ -123,7 +130,7 @@ export const useWizard = ({
       nextStep: () => goToStep(stepIndex + 1),
       previousStep: () => goToStep(Math.max(stepIndex - 1, 0)),
       resetToStep: () => goToStep(stepIndex, { resetMaxStepIndex: true }),
-      moveToStep: () => goToStep(stepIndex)
+      moveToStep: () => goToStep(stepIndex),
     };
     stepCheckIndex++;
     return stepState;
@@ -133,7 +140,7 @@ export const useWizard = ({
     stepIndex: number,
     {
       resetMaxStepIndex = false,
-      skipOnChangeHandler = false
+      skipOnChangeHandler = false,
     }: GoToStepOptions = {}
   ) => {
     if (activeStepIndex !== stepIndex) {
@@ -145,7 +152,7 @@ export const useWizard = ({
         onChange({
           previousStepIndex: activeStepIndex,
           newStepIndex: stepIndex,
-          maxActivatedStepIndex: newMaxStepIndex
+          maxActivatedStepIndex: newMaxStepIndex,
         });
       }
 
@@ -178,7 +185,7 @@ export const useWizard = ({
     previousStep,
     getStep,
     moveToStep,
-    resetToStep
+    resetToStep,
   };
 };
 
@@ -191,7 +198,7 @@ export interface WizardProps {
 export const Wizard: FunctionComponent<WizardProps> = (props: WizardProps) => {
   const internalState = useWizard({
     initialStepIndex: props.initialStepIndex,
-    onChange: props.onChange
+    onChange: props.onChange,
   });
   return (
     <WizardContext.Provider value={{ ...internalState }}>
@@ -230,7 +237,7 @@ export const WizardStep: FunctionComponent<WizardStepProps> = (
   if (contextRef.current !== wizardContext) {
     contextRef.current = wizardContext;
     stepRef.current = wizardContext.getStep({
-      routeTitle: props.routeTitle
+      routeTitle: props.routeTitle,
     });
   }
 

--- a/tests/routing.spec.tsx
+++ b/tests/routing.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Wizard, WizardStep } from "../src";
+import { Wizard, WizardStep, useWizard } from "../src";
 import { cleanup, fireEvent, render } from "react-testing-library";
 import * as routing from "../src/routing";
 
@@ -131,6 +131,21 @@ const TestComponentWithoutAnyRouteTitles = () => {
   );
 };
 
+const ConditionallyRenderedSteps = () => {
+  const { getStep } = useWizard();
+  const [list, setList] = React.useState<string[]>([]);
+  return (
+    <div>
+      {list.map(
+        (entry) =>
+          getStep({ routeTitle: entry }).isActive && (
+            <div key={entry}>{entry}</div>
+          )
+      )}
+    </div>
+  );
+};
+
 const verifyOnlyFirstStepIsVisible = (container: any) => {
   expect(container.queryByTestId("step-1")).toBeTruthy();
   expect(container.queryByTestId("step-2")).toBeNull();
@@ -217,4 +232,10 @@ test("it should not update hash location if window is not defined (ssr)", () => 
 
   expect(window.location.hash).toBe("");
   expect(consoleSpy).not.toBeCalled();
+});
+
+test("it should work with conditionally rendered steps", () => {
+  const { rerender } = render(<ConditionallyRenderedSteps />);
+  rerender(<ConditionallyRenderedSteps />);
+  expect(window.location.hash).toBe("");
 });


### PR DESCRIPTION
if getStep was called after the initial render of useWizard, the stepCheckIndex would be 0, causing
the determination of allStepTitlesAvailable to be true, even if none were provided. Because none
were provided it resulted in the hash being set to undefined.

closes #39 